### PR TITLE
Pick important fixes from ye2015 instance

### DIFF
--- a/actdocs/templates/talk/add
+++ b/actdocs/templates/talk/add
@@ -76,6 +76,7 @@
                   <span class="label label-success">{{confirmed}}</span>
                 [% ELSIF accepted %]
                   <span class="label label-info">{{Accepted}}</span> (not confirmed)
+                  <input type="checkbox" name="confirmed" /> {{confirmed}}<br />
                 [% ELSE %]
                   <span class="label label-warning">{{Pending}}</span>
                 [% END %]

--- a/actdocs/templates/talk/add
+++ b/actdocs/templates/talk/add
@@ -76,7 +76,7 @@
                   <span class="label label-success">{{confirmed}}</span>
                 [% ELSIF accepted %]
                   <span class="label label-info">{{Accepted}}</span> (not confirmed)
-                  <input type="checkbox" name="confirmed" /> {{confirmed}}<br />
+                  <input type="checkbox" name="confirmed"[% ' checked' IF confirmed %] /> {{confirmed}}<br />
                 [% ELSE %]
                   <span class="label label-warning">{{Pending}}</span>
                 [% END %]

--- a/actdocs/templates/talk/add
+++ b/actdocs/templates/talk/add
@@ -72,10 +72,8 @@
                 {{confirmed}}<br />
               [% ELSE %]
                 <div class="form-control-static">
-                [% IF confirmed %]
-                  <span class="label label-success">{{confirmed}}</span>
-                [% ELSIF accepted %]
-                  <span class="label label-info">{{Accepted}}</span> (not confirmed)
+                [% IF accepted %]
+                  <span class="label label-info">{{Accepted}}</span>
                   <input type="checkbox" name="confirmed"[% ' checked' IF confirmed %] /> {{confirmed}}<br />
                 [% ELSE %]
                   <span class="label label-warning">{{Pending}}</span>


### PR DESCRIPTION
We fixed an important issue regarding the talk confirmation which caused some misunderstandings for speakers that had already confirmed their talk but the _confirm_ status was reset after editing other parts of their talk.
