### PR TITLE
Undo ignoring of actdocs/conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-actdocs/conf


### PR DESCRIPTION
Ignoring actdocs/conf is a bad idea for Act instance repositories, which manage Act configuration too.

If developers want to avoid committing their own private Act configuration should use `.git/info/exclude` file instead.
